### PR TITLE
Updated setup.py install requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ starfile
 streamlit
 streamlit-aggrid
 matplotlib
+skimage
+pyopengl
+glfw

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,10 @@ setup(
         "starfile",
         "tqdm",
         "mrcfile",
-        "scipy"
+        "scipy",
+        "glfw",
+        "pyopengl",
+        "skimage"
     ]
 )
 


### PR DESCRIPTION
We installed Pom with `pip install git+https://github.com/bionanopatterning/Pom.git` as a module on our cluster, but to get `pom render` to run properly, we had to manually install `glfw`, `pyopengl`, and `skimage`. Maybe these could be included in the `setup.py` file?